### PR TITLE
chore: disable push trigger for PR agent

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,8 +1,8 @@
 on:
-  push:
-    branches:
-      - "dev*"
-      - "test*"
+  # push:
+  #   branches:
+  #     - "dev*"
+  #     - "test*"
   pull_request:
     types: [opened, reopened, ready_for_review]
   issue_comment:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable push trigger for PR agent.

- Workflow no longer runs on push events.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Disable push trigger for PR agent workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Commented out the <code>push</code> event trigger configuration.<br> <li> The workflow will no longer be activated on <code>push</code> events to <code>dev*</code> or <br><code>test*</code> branches.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/14/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

