### PR TITLE
ci: trigger black-action on more pull request events

### DIFF
--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -2,7 +2,7 @@ name: black-action
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Black formatter workflow triggers.

- Trigger on specific pull request events.

- Enable re-triggering via issue comments.

- Remove automatic push event trigger.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pull Request Events"] -- "opened, reopened, ready_for_review" --> B["Black Formatter Workflow"]
  C["Issue Comment Created"] -- "created" --> B
  D["Workflow Dispatch"] -- "manual trigger" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>black_formatter.yml</strong><dd><code>Update Black formatter workflow triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/black_formatter.yml

<ul><li>Updated the <code>pull_request</code> event to trigger the workflow specifically on <br><code>opened</code>, <code>reopened</code>, and <code>ready_for_review</code> types.<br> <li> Added a new <code>issue_comment</code> event trigger, allowing the workflow to run <br>when a comment is <code>created</code>.<br> <li> Removed the <code>push</code> event trigger, preventing the workflow from running <br>on every code push.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/17/files#diff-feca1d811642b69c71ffcad5eab7f4a823a640f3a063b7dac2ef290a1d077c89">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

