### PR TITLE
fix: delete docstring in the pronpt for fixing process when we did not choose "--include-docstring" option

### DIFF
--- a/run_test_case_generator.py
+++ b/run_test_case_generator.py
@@ -989,11 +989,19 @@ Start your response with "import pytest" and include only executable Python test
         total_fix_attempts = self.get_total_fix_attempts()
         fix_attempt_line = f"This is fix attempt {attempt} of {total_fix_attempts}."
 
+        # Get function info based on include_docstring flag
+        if self.include_docstring:
+            function_info = problem['prompt']
+        else:
+            function_info = self.extract_function_signature(
+                problem['prompt'], problem['entry_point']
+            )
+
         return f"""The following test code has errors when running pytest. Please fix the issues and return ONLY the corrected Python code, no explanations or markdown.
 
 FUNCTION BEING TESTED (WHITE BOX):
 ```python
-{problem['prompt']}
+{function_info}
 {problem['canonical_solution']}
 ```
 {ast_section}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Exclude docstrings from fix prompt when `include_docstring` is false.

- Extract only function signature for prompt if docstrings are not included.

- Apply minor code formatting and alignment improvements.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_test_case_generator.py</strong><dd><code>Conditional Docstring Inclusion in Prompt and Formatting</code>&nbsp; </dd></summary>
<hr>

run_test_case_generator.py

<ul><li>Modified the <code>generate_fix_prompt</code> method to conditionally include or <br>exclude docstrings from the <code>FUNCTION BEING TESTED</code> section.<br> <li> Implemented logic to extract only the function signature for the <br>prompt when the <code>include_docstring</code> option is not selected.<br> <li> Applied minor code formatting adjustments, including consistent string <br>literal usage and improved line breaks for readability.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/31/files#diff-14d335a0de23e2987dfee5f7b114ff6c4208051594b743fe151c537339a54a65">+30/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

