### PR TITLE
fix: delete the function signature when do not choose '--include-docs…

### DIFF
--- a/run_test_case_generator.py
+++ b/run_test_case_generator.py
@@ -560,9 +560,9 @@ class TestCaseGenerator:
         # since the canonical implementation below already includes the signature.
         signature_section = ""
         if self.include_docstring:
-            # Include full function signature with docstring
+            # Include full function definition (signature + docstring)
             function_info = problem["prompt"]
-            signature_section = f"\nDocstring:\n{function_info}\n\n"
+            signature_section = f"\nSignature and Docstring:\n{function_info}\n\n"
 
         ast_section = ""
         if self.include_ast:


### PR DESCRIPTION
### **User description**
…tring' option


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Eliminate redundant function signature in prompts.

- Conditionally include docstring section.

- Improve robustness for missing problem data.

- Simplify prompt header in fix attempts.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_test_case_generator.py</strong><dd><code>Refactor prompt generation to remove redundancy and improve robustness</code></dd></summary>
<hr>

run_test_case_generator.py

<ul><li>Refactored the <code>generate_prompt</code> method to remove the explicit "Function <br>signature" section when <code>--include-docstring</code> is not enabled, preventing <br>redundancy with the "Canonical implementation".<br> <li> Modified <code>generate_prompt</code> to introduce a <code>signature_section</code> that is <br>populated only when <code>include_docstring</code> is true.<br> <li> Enhanced the <code>generate_fix_prompt</code> method to use <code>.get()</code> for safer access <br>to <code>problem</code> dictionary keys like <code>prompt</code> and <code>entry_point</code>, providing <br>default empty strings.<br> <li> Simplified the "FUNCTION BEING TESTED" header in the <br><code>generate_fix_prompt</code> method.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/33/files#diff-14d335a0de23e2987dfee5f7b114ff6c4208051594b743fe151c537339a54a65">+18/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

