### PR TITLE
update: change the option of "--show-prompt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ python run_batch_test_case_generator.py --start 0 --end 10
 | `--api-key`            | Claude API key                                                                                               | From .env or environment     |
 | `--include-docstring`  | Include function docstring in prompt                                                                         | `False` (signature only)     |
 | `--include-ast`        | Include AST of canonical solution in prompt                                                                  | `False`                      |
-| `--show-prompt`        | Display prompt before sending to LLM and ask for confirmation                                                | `False`                      |
+| `--show-prompt`        | Display prompt before sending to LLM and ask for confirmation (use `--no-show-prompt` to disable)            | `True`                       |
 | `--disable-evaluation` | Disable automatic test evaluation and error fixing                                                           | `False` (evaluation enabled) |
 | `--max-pytest-runs`    | Total pytest runs (initial + fixes)                                                                          | `3`                          |
 | `--quiet-evaluation`   | Disable verbose output during error fixing process                                                           | `False` (verbose enabled)    |
@@ -177,10 +177,10 @@ python run_test_case_generator.py --include-ast
 python run_test_case_generator.py --ast-fix
 ```
 
-#### Preview prompt before sending to LLM:
+#### Disable prompt preview for automation:
 
 ```bash
-python run_test_case_generator.py --show-prompt
+python run_test_case_generator.py --no-show-prompt
 ```
 
 #### Use custom dataset and output directory:
@@ -192,7 +192,7 @@ python run_test_case_generator.py --dataset path/to/custom.jsonl --output-dir my
 #### Combine options:
 
 ```bash
-python run_test_case_generator.py --task-id "HumanEval/5" --include-docstring --include-ast --show-prompt --output-dir custom_tests
+python run_test_case_generator.py --task-id "HumanEval/5" --include-docstring --include-ast --no-show-prompt --output-dir custom_tests
 ```
 
 #### Combine with AST-focused error fixing:
@@ -238,8 +238,8 @@ python run_test_case_generator.py --task-id "HumanEval/0" --max-pytest-runs 5
 # Quiet mode (less verbose output during fixing)
 python run_test_case_generator.py --task-id "HumanEval/0" --quiet-evaluation
 
-# Interactive mode (approve each fix attempt)
-python run_test_case_generator.py --task-id "HumanEval/0" --show-prompt
+# Non-interactive mode (skip confirmations)
+python run_test_case_generator.py --task-id "HumanEval/0" --no-show-prompt
 ```
 
 #### White Box Error Fixing
@@ -657,12 +657,11 @@ python run_test_case_generator.py --include-docstring --include-ast
 
 ### Interactive Prompt Preview
 
-Use `--show-prompt` to:
+By default, prompt preview is enabled. Use `--no-show-prompt` to:
 
-- Preview the exact prompt that will be sent to Claude
-- See estimated token count and cost
-- Decide whether to proceed, modify, or cancel
-- Avoid unexpected API charges
+- Skip the preview of the prompt sent to Claude
+- Avoid interactive confirmations in automated contexts
+- Prevent "EOF when reading a line" in non-interactive environments
 
 ### Pricing Information
 
@@ -781,10 +780,10 @@ Each `.stats.json` file contains:
    - The generated tests import the function from the same file
    - Make sure to run pytest from the correct directory
 
-5. **EOF when reading a line (with --show-prompt)**
+5. **EOF when reading a line (prompt preview enabled)**
 
    - This happens when running non-interactively
-   - Either run in an interactive terminal or omit `--show-prompt`
+   - Either run in an interactive terminal or add `--no-show-prompt`
 
 6. **Syntax errors in generated pytest code**
 
@@ -827,7 +826,7 @@ python run_test_case_generator.py --task-id "HumanEval/0" --include-docstring --
 
 ### Cost-Effective Workflow
 
-1. Start with `--show-prompt` to understand token usage
+1. By default, prompt preview helps you understand token usage
 2. Use basic generation for simple functions
 3. Add `--include-docstring` for complex functions needing examples
 4. Add `--include-ast` for functions with complex logic structure

--- a/batch/README.md
+++ b/batch/README.md
@@ -168,7 +168,7 @@ The batch generator includes robust error handling:
 
 ## Integration with Main Tool
 
-The batch generator wraps the main `run_test_case_generator.py` tool, passing through all supported options. Ensure the main generator is in the same directory.
+The batch generator wraps the main `run_test_case_generator.py` tool. It always runs in non-interactive mode by forcing `--no-show-prompt` to avoid hangs. If you want interactive prompt previews, use the single-run tool directly.
 
 ## Requirements
 

--- a/batch/run_batch_test_case_generator.py
+++ b/batch/run_batch_test_case_generator.py
@@ -90,6 +90,8 @@ class BatchTestGenerator:
             cmd.append("--disable-evaluation")
         if self.quiet_evaluation:
             cmd.append("--quiet-evaluation")
+        # Always force non-interactive mode for batch runs
+        cmd.append("--no-show-prompt")
 
         return cmd
 

--- a/run_test_case_generator.py
+++ b/run_test_case_generator.py
@@ -1413,8 +1413,12 @@ def main():
     )
     parser.add_argument(
         "--show-prompt",
-        action="store_true",
-        help="Display the prompt before sending to LLM and ask for confirmation",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Display the prompt before sending to LLM and ask for confirmation "
+            "(default: True; use --no-show-prompt to disable)"
+        ),
     )
     parser.add_argument(
         "--disable-evaluation",


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Make `--show-prompt` option enabled by default.

- Introduce `--no-show-prompt` to disable prompt preview.

- Force non-interactive mode for batch test generation.

- Update documentation to reflect new default behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User[User Interaction] --> run_test_case_generator_py;
  run_test_case_generator_py -- "Default: Show Prompt" --> PromptPreview[Prompt Preview];
  run_test_case_generator_py -- "Explicit --no-show-prompt" --> NoPrompt[Skip Prompt Preview];
  BatchGenerator[batch/run_batch_test_case_generator.py] -- "Forces --no-show-prompt" --> run_test_case_generator_py;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_batch_test_case_generator.py</strong><dd><code>Force non-interactive mode for batch runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

batch/run_batch_test_case_generator.py

<ul><li>Added <code>--no-show-prompt</code> to the command list for batch runs.<br> <li> Ensures batch test generation always operates in non-interactive mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/34/files#diff-63340ca85aa2713b7146445d030d169a9d91ad7b787db91a976e09ddfd17e0ac">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_test_case_generator.py</strong><dd><code>Make `--show-prompt` default and add `--no-show-prompt`</code>&nbsp; &nbsp; </dd></summary>
<hr>

run_test_case_generator.py

<ul><li>Changed <code>--show-prompt</code> to use <code>argparse.BooleanOptionalAction</code>.<br> <li> Set the default value of <code>--show-prompt</code> to <code>True</code>.<br> <li> Updated the help text to indicate the new default and the <br><code>--no-show-prompt</code> option.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/34/files#diff-14d335a0de23e2987dfee5f7b114ff6c4208051594b743fe151c537339a54a65">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for new prompt preview default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated the <code>--show-prompt</code> entry in the arguments table to reflect the <br>new default (<code>True</code>) and mention <code>--no-show-prompt</code>.<br> <li> Revised command examples to use <code>--no-show-prompt</code> for disabling the <br>prompt preview.<br> <li> Updated sections like "Interactive Prompt Preview" and "EOF when <br>reading a line" to explain the new default behavior and the use of <br><code>--no-show-prompt</code>.<br> <li> Made a minor text change from "FUNCTION BEING TESTED (WHITE BOX):" to <br>"FUNCTION BEING TESTED:".</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+14/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document batch generator's forced non-interactive mode</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

batch/README.md

<ul><li>Updated the integration description to clarify that the batch <br>generator forces <code>--no-show-prompt</code>.<br> <li> Explained the rationale for forcing non-interactive mode in batch <br>runs.</ul>


</details>


  </td>
  <td><a href="https://github.com/soso0024/pj-aidev-CHI2026/pull/34/files#diff-122029876ab6a1d79eac536b2bfef7bdbcc48b237093c292a85e44e299e716ce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

